### PR TITLE
Bump backtrace-rs

### DIFF
--- a/color-eyre/Cargo.toml
+++ b/color-eyre/Cargo.toml
@@ -20,7 +20,7 @@ track-caller = []
 [dependencies]
 eyre = "0.6.1"
 tracing-error = { version = "0.2.0", optional = true }
-backtrace = { version = "0.3.48", features = ["gimli-symbolize"] }
+backtrace = { version = "0.3.59" }
 indenter = { workspace = true }
 owo-colors = { workspace = true }
 color-spantrace = { version = "0.2", path = "../color-spantrace", optional = true }


### PR DESCRIPTION
0.3.59 is the first version of backtrace-rs that doesn't use `gimli-symbolize`: https://github.com/rust-lang/backtrace-rs/commit/5fc4f79674206c2041b9ffeec6e3891c73510147

While the feature is still there, it is unused, and later on removed
in
https://github.com/rust-lang/backtrace-rs/commit/4cbe6b69eaccf23297b51f9584dd8a7d5e12ea95. Original
[PR #615](https://github.com/rust-lang/backtrace-rs/pull/615)
